### PR TITLE
Add advanced AI parameters controls to fix incomplete code generation

### DIFF
--- a/includes/admin/class-settings.php
+++ b/includes/admin/class-settings.php
@@ -38,5 +38,59 @@ class Settings {
 		register_setting( 'wp_autoplugin_settings', 'wp_autoplugin_coder_model' );
 		register_setting( 'wp_autoplugin_settings', 'wp_autoplugin_reviewer_model' );
 		register_setting( 'wp_autoplugin_settings', 'wp_autoplugin_plugin_mode' );
+
+		// Advanced AI Parameters.
+		register_setting( 'wp_autoplugin_settings', 'wp_autoplugin_max_tokens', [
+			'type'              => 'integer',
+			'default'           => 0,
+			'sanitize_callback' => 'absint',
+		] );
+		register_setting( 'wp_autoplugin_settings', 'wp_autoplugin_temperature', [
+			'type'              => 'number',
+			'default'           => 0,
+			'sanitize_callback' => [ $this, 'sanitize_temperature' ],
+		] );
+		register_setting( 'wp_autoplugin_settings', 'wp_autoplugin_top_p', [
+			'type'              => 'number',
+			'default'           => 0,
+			'sanitize_callback' => [ $this, 'sanitize_top_p' ],
+		] );
+		register_setting( 'wp_autoplugin_settings', 'wp_autoplugin_seed', [
+			'type'              => 'integer',
+			'sanitize_callback' => 'absint',
+		] );
+		register_setting( 'wp_autoplugin_settings', 'wp_autoplugin_stop_sequences' );
+		register_setting( 'wp_autoplugin_settings', 'wp_autoplugin_response_format', [
+			'type'    => 'string',
+			'default' => '',
+		] );
+	}
+
+	/**
+	 * Sanitize temperature value.
+	 *
+	 * @param mixed $value The value to sanitize.
+	 * @return float
+	 */
+	public function sanitize_temperature( $value ) {
+		$value = floatval( $value );
+		if ( $value < 0 || $value > 2 ) {
+			return 0;
+		}
+		return $value;
+	}
+
+	/**
+	 * Sanitize top_p value.
+	 *
+	 * @param mixed $value The value to sanitize.
+	 * @return float
+	 */
+	public function sanitize_top_p( $value ) {
+		$value = floatval( $value );
+		if ( $value < 0 || $value > 1 ) {
+			return 0;
+		}
+		return $value;
 	}
 }

--- a/includes/api/class-anthropic-api.php
+++ b/includes/api/class-anthropic-api.php
@@ -122,6 +122,20 @@ class Anthropic_API extends API {
 	 * @return mixed The response from the API.
 	 */
 	public function send_prompt( $prompt, $system_message = '', $override_body = [] ) {
+		// Read advanced settings from WordPress options.
+		$advanced_max_tokens     = get_option( 'wp_autoplugin_max_tokens', 0 );
+		$advanced_temperature    = get_option( 'wp_autoplugin_temperature', 0 );
+		$advanced_top_p          = get_option( 'wp_autoplugin_top_p', 0 );
+		$advanced_stop_sequences = get_option( 'wp_autoplugin_stop_sequences', '' );
+
+		// Override defaults with advanced settings if they are set.
+		if ( ! empty( $advanced_max_tokens ) ) {
+			$this->max_tokens = intval( $advanced_max_tokens );
+		}
+		if ( ! empty( $advanced_temperature ) ) {
+			$this->temperature = floatval( $advanced_temperature );
+		}
+
 		$payload = [
 			'model'       => $this->model,
 			'temperature' => $this->temperature,
@@ -143,6 +157,18 @@ class Anthropic_API extends API {
 			$payload['system'] = $system_message;
 		}
 
+		// Add advanced parameters if set.
+		if ( ! empty( $advanced_top_p ) ) {
+			$payload['top_p'] = floatval( $advanced_top_p );
+		}
+		if ( ! empty( $advanced_stop_sequences ) ) {
+			$stop_sequences = array_filter( array_map( 'trim', explode( "\n", $advanced_stop_sequences ) ) );
+			if ( ! empty( $stop_sequences ) ) {
+				// Anthropic uses 'stop_sequences' parameter.
+				$payload['stop_sequences'] = array_slice( $stop_sequences, 0, 4 ); // Max 4 stop sequences.
+			}
+		}
+
 		if ( isset( $override_body['messages'] ) ) {
 			$payload['messages'] = $override_body['messages'];
 			unset( $override_body['messages'] );
@@ -154,7 +180,7 @@ class Anthropic_API extends API {
 		}
 
 		// Keep only allowed keys alongside overrides.
-		$allowed_keys  = [ 'model', 'temperature', 'max_tokens', 'messages', 'system', 'thinking' ];
+		$allowed_keys  = [ 'model', 'temperature', 'max_tokens', 'messages', 'system', 'thinking', 'top_p', 'stop_sequences' ];
 		$override_body = array_intersect_key( $override_body, array_flip( $allowed_keys ) );
 		$body          = array_merge( $payload, $override_body );
 

--- a/includes/api/class-custom-api.php
+++ b/includes/api/class-custom-api.php
@@ -53,6 +53,22 @@ class Custom_API extends OpenAI_API {
 	 * @return string|\WP_Error The response or a WP_Error object on failure.
 	 */
 	public function send_prompt( $prompt, $system_message = '', $override_body = [] ) {
+		// Read advanced settings from WordPress options.
+		$advanced_max_tokens      = get_option( 'wp_autoplugin_max_tokens', 0 );
+		$advanced_temperature     = get_option( 'wp_autoplugin_temperature', 0 );
+		$advanced_top_p           = get_option( 'wp_autoplugin_top_p', 0 );
+		$advanced_seed            = get_option( 'wp_autoplugin_seed', '' );
+		$advanced_stop_sequences  = get_option( 'wp_autoplugin_stop_sequences', '' );
+		$advanced_response_format = get_option( 'wp_autoplugin_response_format', '' );
+
+		// Override defaults with advanced settings if they are set.
+		if ( ! empty( $advanced_max_tokens ) ) {
+			$this->max_tokens = intval( $advanced_max_tokens );
+		}
+		if ( ! empty( $advanced_temperature ) ) {
+			$this->temperature = floatval( $advanced_temperature );
+		}
+
 		$messages = [];
 		if ( $system_message ) {
 			$messages[] = [
@@ -72,6 +88,23 @@ class Custom_API extends OpenAI_API {
 			'max_tokens'  => $this->max_tokens,
 			'messages'    => $messages,
 		];
+
+		// Add advanced parameters if set.
+		if ( ! empty( $advanced_top_p ) ) {
+			$body['top_p'] = floatval( $advanced_top_p );
+		}
+		if ( ! empty( $advanced_seed ) ) {
+			$body['seed'] = intval( $advanced_seed );
+		}
+		if ( ! empty( $advanced_stop_sequences ) ) {
+			$stop_sequences = array_filter( array_map( 'trim', explode( "\n", $advanced_stop_sequences ) ) );
+			if ( ! empty( $stop_sequences ) ) {
+				$body['stop'] = array_slice( $stop_sequences, 0, 4 ); // Max 4 stop sequences.
+			}
+		}
+		if ( ! empty( $advanced_response_format ) && 'json_object' === $advanced_response_format ) {
+			$body['response_format'] = [ 'type' => 'json_object' ];
+		}
 
 		// Only keep valid keys from $override_body.
 		$allowed_keys  = $this->get_allowed_parameters();

--- a/includes/api/class-google-gemini-api.php
+++ b/includes/api/class-google-gemini-api.php
@@ -60,6 +60,17 @@ class Google_Gemini_API extends API {
 	 * @return mixed
 	 */
 	public function send_prompt( $prompt, $system_message = '', $override_body = [] ) {
+		// Read advanced settings from WordPress options.
+		$advanced_max_tokens  = get_option( 'wp_autoplugin_max_tokens', 0 );
+		$advanced_temperature = get_option( 'wp_autoplugin_temperature', 0 );
+		$advanced_top_p       = get_option( 'wp_autoplugin_top_p', 0 );
+		$advanced_seed        = get_option( 'wp_autoplugin_seed', '' );
+
+		// Override defaults with advanced settings if they are set.
+		if ( ! empty( $advanced_temperature ) ) {
+			$this->temperature = floatval( $advanced_temperature );
+		}
+
 		$url = 'https://generativelanguage.googleapis.com/v1beta/models/' . $this->model . ':generateContent?key=' . $this->api_key;
 
 		// Set max tokens for Gemini 2.5 Flash & Pro.
@@ -69,6 +80,11 @@ class Google_Gemini_API extends API {
 			stripos( $this->model, 'gemini-2.5-flash' ) !== false
 		) {
 			$max_tokens = 65535;
+		}
+
+		// Override with advanced setting if set.
+		if ( ! empty( $advanced_max_tokens ) ) {
+			$max_tokens = intval( $advanced_max_tokens );
 		}
 
 		// Default safetySettings.
@@ -84,6 +100,14 @@ class Google_Gemini_API extends API {
 			'temperature'     => $this->temperature,
 			'maxOutputTokens' => $max_tokens,
 		];
+
+		// Add advanced parameters if set.
+		if ( ! empty( $advanced_top_p ) ) {
+			$generation_config['topP'] = floatval( $advanced_top_p );
+		}
+		if ( ! empty( $advanced_seed ) ) {
+			$generation_config['seed'] = intval( $advanced_seed );
+		}
 
 		// Merge override_body['generationConfig'] into $generation_config.
 		if ( isset( $override_body['generationConfig'] ) && is_array( $override_body['generationConfig'] ) ) {

--- a/includes/api/class-openai-api.php
+++ b/includes/api/class-openai-api.php
@@ -197,6 +197,22 @@ class OpenAI_API extends API {
 	 * @param array  $override_body The override body.
 	 */
 	public function send_prompt( $prompt, $system_message = '', $override_body = [] ) {
+		// Read advanced settings from WordPress options.
+		$advanced_max_tokens      = get_option( 'wp_autoplugin_max_tokens', 0 );
+		$advanced_temperature     = get_option( 'wp_autoplugin_temperature', 0 );
+		$advanced_top_p           = get_option( 'wp_autoplugin_top_p', 0 );
+		$advanced_seed            = get_option( 'wp_autoplugin_seed', '' );
+		$advanced_stop_sequences  = get_option( 'wp_autoplugin_stop_sequences', '' );
+		$advanced_response_format = get_option( 'wp_autoplugin_response_format', '' );
+
+		// Override defaults with advanced settings if they are set.
+		if ( ! empty( $advanced_max_tokens ) ) {
+			$this->max_tokens = intval( $advanced_max_tokens );
+		}
+		if ( ! empty( $advanced_temperature ) ) {
+			$this->temperature = floatval( $advanced_temperature );
+		}
+
 		$messages = [];
 		if ( ! empty( $system_message ) ) {
 			$messages[] = [
@@ -226,6 +242,23 @@ class OpenAI_API extends API {
 		} else {
 			$body['temperature'] = $this->temperature;
 			$body['max_tokens']  = $this->max_tokens;
+		}
+
+		// Add advanced parameters if set.
+		if ( ! empty( $advanced_top_p ) ) {
+			$body['top_p'] = floatval( $advanced_top_p );
+		}
+		if ( ! empty( $advanced_seed ) ) {
+			$body['seed'] = intval( $advanced_seed );
+		}
+		if ( ! empty( $advanced_stop_sequences ) ) {
+			$stop_sequences = array_filter( array_map( 'trim', explode( "\n", $advanced_stop_sequences ) ) );
+			if ( ! empty( $stop_sequences ) ) {
+				$body['stop'] = array_slice( $stop_sequences, 0, 4 ); // Max 4 stop sequences.
+			}
+		}
+		if ( ! empty( $advanced_response_format ) && 'json_object' === $advanced_response_format ) {
+			$body['response_format'] = [ 'type' => 'json_object' ];
 		}
 
 		// Keep only allowed keys in the override body.
@@ -322,6 +355,9 @@ class OpenAI_API extends API {
 			'reasoning_effort',
 			'messages',
 			'response_format',
+			'top_p',
+			'seed',
+			'stop',
 		];
 	}
 

--- a/includes/api/class-openai-responses-api.php
+++ b/includes/api/class-openai-responses-api.php
@@ -40,6 +40,15 @@ class OpenAI_Responses_API extends OpenAI_API {
 	 * @return string|\WP_Error
 	 */
 	public function send_prompt( $prompt, $system_message = '', $override_body = [] ) {
+		// Read advanced settings from WordPress options.
+		$advanced_max_tokens = get_option( 'wp_autoplugin_max_tokens', 0 );
+		$advanced_top_p      = get_option( 'wp_autoplugin_top_p', 0 );
+
+		// Override defaults with advanced settings if they are set.
+		if ( ! empty( $advanced_max_tokens ) ) {
+			$this->max_tokens = intval( $advanced_max_tokens );
+		}
+
 		$body = [
 			'model' => $this->model,
 			'input' => $prompt,
@@ -58,6 +67,11 @@ class OpenAI_Responses_API extends OpenAI_API {
 			$body['reasoning'] = [
 				'effort' => $this->reasoning_effort,
 			];
+		}
+
+		// Add advanced parameters if set.
+		if ( ! empty( $advanced_top_p ) ) {
+			$body['top_p'] = floatval( $advanced_top_p );
 		}
 
 		// Ignore response_format for the Responses API (incompatible with text.format expectations).

--- a/includes/api/class-xai-api.php
+++ b/includes/api/class-xai-api.php
@@ -62,6 +62,10 @@ class XAI_API extends OpenAI_API {
 			'temperature',
 			'max_tokens',
 			'messages',
+			'response_format',
+			'top_p',
+			'seed',
+			'stop',
 		];
 	}
 }

--- a/views/page-settings.php
+++ b/views/page-settings.php
@@ -145,8 +145,107 @@ function render_model_dropdown( $name, $selected_value ) {
 					<p class="description">
 						<?php esc_html_e( 'Complex mode uses more tokens. For best results, use capable models.', 'wp-autoplugin' ); ?>
 					</p>
+					<p>
+						<button type="button" id="toggle-advanced-params" class="button-link"><?php esc_html_e( 'Show advanced AI parameters', 'wp-autoplugin' ); ?> <span class="dashicons dashicons-arrow-down-alt2"></span></button>
+					</p>
 				</td>
 			</tr>
+		</table>
+
+		<?php
+		// Check if any advanced parameter is set.
+		$max_tokens       = get_option( 'wp_autoplugin_max_tokens', 0 );
+		$temperature      = get_option( 'wp_autoplugin_temperature', 0 );
+		$top_p            = get_option( 'wp_autoplugin_top_p', 0 );
+		$seed             = get_option( 'wp_autoplugin_seed', '' );
+		$stop_sequences   = get_option( 'wp_autoplugin_stop_sequences', '' );
+		$response_format  = get_option( 'wp_autoplugin_response_format', '' );
+		$has_advanced     = ! empty( $max_tokens ) || ! empty( $temperature ) || ! empty( $top_p ) || ! empty( $seed ) || ! empty( $stop_sequences ) || ! empty( $response_format );
+		?>
+		<div class="wp-autoplugin-advanced-params" style="<?php echo $has_advanced ? '' : 'display: none;'; ?>">
+			<h3><?php esc_html_e( 'Advanced AI Parameters', 'wp-autoplugin' ); ?></h3>
+			<p class="description" style="margin-bottom: 20px;">
+				<?php esc_html_e( 'These parameters override the default model settings. Leave empty (or 0) to use the model defaults. Changing these values may affect the quality and consistency of generated code.', 'wp-autoplugin' ); ?>
+			</p>
+			<table class="form-table">
+				<tr valign="top">
+					<th scope="row">
+						<?php esc_html_e( 'Max Tokens', 'wp-autoplugin' ); ?>
+						<span class="dashicons dashicons-info" title="<?php esc_attr_e( 'Maximum number of tokens to generate. Higher values allow longer code outputs. Set to 0 to use model default.', 'wp-autoplugin' ); ?>"></span>
+					</th>
+					<td>
+						<input type="number" name="wp_autoplugin_max_tokens" value="<?php echo esc_attr( $max_tokens ); ?>" min="0" max="200000" step="1" class="regular-text" />
+						<p class="description">
+							<?php esc_html_e( 'Recommended: 16384 or higher for complex plugins. 0 = use model default. Higher values prevent code truncation but increase API costs.', 'wp-autoplugin' ); ?>
+						</p>
+					</td>
+				</tr>
+				<tr valign="top">
+					<th scope="row">
+						<?php esc_html_e( 'Temperature', 'wp-autoplugin' ); ?>
+						<span class="dashicons dashicons-info" title="<?php esc_attr_e( 'Controls randomness. Lower values (0.0-0.5) make output more deterministic, higher values (0.5-2.0) make it more creative.', 'wp-autoplugin' ); ?>"></span>
+					</th>
+					<td>
+						<input type="number" name="wp_autoplugin_temperature" value="<?php echo esc_attr( $temperature ); ?>" min="0" max="2" step="0.1" class="regular-text" />
+						<p class="description">
+							<?php esc_html_e( 'Range: 0.0 to 2.0. Recommended: 0.2 for code generation. 0 = use model default.', 'wp-autoplugin' ); ?>
+						</p>
+					</td>
+				</tr>
+				<tr valign="top">
+					<th scope="row">
+						<?php esc_html_e( 'Top P', 'wp-autoplugin' ); ?>
+						<span class="dashicons dashicons-info" title="<?php esc_attr_e( 'Nucleus sampling. Controls diversity of output by limiting token choices to top probability mass.', 'wp-autoplugin' ); ?>"></span>
+					</th>
+					<td>
+						<input type="number" name="wp_autoplugin_top_p" value="<?php echo esc_attr( $top_p ); ?>" min="0" max="1" step="0.05" class="regular-text" />
+						<p class="description">
+							<?php esc_html_e( 'Range: 0.0 to 1.0. Recommended: 0.9-1.0. 0 = use model default. Not recommended to use with Temperature.', 'wp-autoplugin' ); ?>
+						</p>
+					</td>
+				</tr>
+				<tr valign="top">
+					<th scope="row">
+						<?php esc_html_e( 'Seed', 'wp-autoplugin' ); ?>
+						<span class="dashicons dashicons-info" title="<?php esc_attr_e( 'Random seed for reproducible outputs. Same seed with same inputs will produce similar outputs.', 'wp-autoplugin' ); ?>"></span>
+					</th>
+					<td>
+						<input type="number" name="wp_autoplugin_seed" value="<?php echo esc_attr( $seed ); ?>" min="0" step="1" class="regular-text" />
+						<p class="description">
+							<?php esc_html_e( 'Any positive integer. Leave empty for random generation. Useful for testing and debugging.', 'wp-autoplugin' ); ?>
+						</p>
+					</td>
+				</tr>
+				<tr valign="top">
+					<th scope="row">
+						<?php esc_html_e( 'Stop Sequences', 'wp-autoplugin' ); ?>
+						<span class="dashicons dashicons-info" title="<?php esc_attr_e( 'Sequences where the API will stop generating further tokens.', 'wp-autoplugin' ); ?>"></span>
+					</th>
+					<td>
+						<textarea name="wp_autoplugin_stop_sequences" rows="3" class="large-text"><?php echo esc_textarea( $stop_sequences ); ?></textarea>
+						<p class="description">
+							<?php esc_html_e( 'One stop sequence per line. Up to 4 sequences. Example: "```" to stop at code blocks.', 'wp-autoplugin' ); ?>
+						</p>
+					</td>
+				</tr>
+				<tr valign="top">
+					<th scope="row">
+						<?php esc_html_e( 'Response Format', 'wp-autoplugin' ); ?>
+						<span class="dashicons dashicons-info" title="<?php esc_attr_e( 'Force structured output format. Only works with compatible models (GPT-4o, GPT-4-turbo, etc.).', 'wp-autoplugin' ); ?>"></span>
+					</th>
+					<td>
+						<select name="wp_autoplugin_response_format" class="regular-text">
+							<option value="" <?php selected( $response_format, '' ); ?>><?php esc_html_e( 'Default (text)', 'wp-autoplugin' ); ?></option>
+							<option value="json_object" <?php selected( $response_format, 'json_object' ); ?>><?php esc_html_e( 'JSON Object', 'wp-autoplugin' ); ?></option>
+						</select>
+						<p class="description">
+							<?php esc_html_e( 'JSON Object mode ensures the model returns valid JSON. Only use when planning mode is enabled.', 'wp-autoplugin' ); ?>
+						</p>
+					</td>
+				</tr>
+			</table>
+		</div>
+		<table class="form-table">
 			<tr valign="top">
 				<th scope="row"><?php esc_html_e( 'Custom Models', 'wp-autoplugin' ); ?></th>
 				<td>
@@ -184,7 +283,7 @@ function render_model_dropdown( $name, $selected_value ) {
 			const $section = $('.wp-autoplugin-per-step-models');
 			const $button = $(this);
 			const $icon = $button.find('.dashicons');
-			
+
 			if ($section.is(':visible')) {
 				$section.hide();
 				$button.html('<?php esc_html_e( 'Show specialized model settings', 'wp-autoplugin' ); ?> <span class="dashicons dashicons-arrow-down-alt2"></span>');
@@ -193,10 +292,27 @@ function render_model_dropdown( $name, $selected_value ) {
 				$button.html('<?php esc_html_e( 'Hide specialized model settings', 'wp-autoplugin' ); ?> <span class="dashicons dashicons-arrow-up-alt2"></span>');
 			}
 		});
+
+		// Toggle advanced parameters section
+		$('#toggle-advanced-params').on('click', function() {
+			const $section = $('.wp-autoplugin-advanced-params');
+			const $button = $(this);
+
+			if ($section.is(':visible')) {
+				$section.hide();
+				$button.html('<?php esc_html_e( 'Show advanced AI parameters', 'wp-autoplugin' ); ?> <span class="dashicons dashicons-arrow-down-alt2"></span>');
+			} else {
+				$section.show();
+				$button.html('<?php esc_html_e( 'Hide advanced AI parameters', 'wp-autoplugin' ); ?> <span class="dashicons dashicons-arrow-up-alt2"></span>');
+			}
+		});
 		
 		// Update toggle button text based on initial visibility
 		if ($('.wp-autoplugin-per-step-models').is(':visible')) {
 			$('#toggle-specialized-models').html('<?php esc_html_e( 'Hide specialized model settings', 'wp-autoplugin' ); ?> <span class="dashicons dashicons-arrow-up-alt2"></span>');
+		}
+		if ($('.wp-autoplugin-advanced-params').is(':visible')) {
+			$('#toggle-advanced-params').html('<?php esc_html_e( 'Hide advanced AI parameters', 'wp-autoplugin' ); ?> <span class="dashicons dashicons-arrow-up-alt2"></span>');
 		}
 		
 		// Later this may be moved to a wp_localize_script call
@@ -439,5 +555,47 @@ function render_model_dropdown( $name, $selected_value ) {
 		border-radius: 4px;
 		padding: 0 2rem;
 		margin-bottom: 15px;
+	}
+
+	/* Advanced Parameters Section */
+	.wp-autoplugin-advanced-params {
+		background: #fff;
+		border: 1px solid #ccd0d4;
+		border-radius: 4px;
+		padding: 0 2rem;
+		margin-bottom: 15px;
+		margin-top: 15px;
+	}
+
+	.wp-autoplugin-advanced-params h3 {
+		margin-top: 10px;
+		padding-top: 10px;
+		color: #1d2327;
+	}
+
+	.wp-autoplugin-advanced-params .dashicons-info {
+		color: #2271b1;
+		cursor: help;
+		font-size: 18px;
+		vertical-align: middle;
+	}
+
+	#toggle-advanced-params {
+		margin-top: 8px;
+		display: block;
+		color: #2271b1;
+		text-decoration: none;
+		padding: 0;
+	}
+
+	#toggle-advanced-params:focus {
+		box-shadow: none;
+		outline: none;
+	}
+
+	#toggle-advanced-params .dashicons {
+		font-size: 16px;
+		line-height: 1.5;
+		vertical-align: middle;
 	}
 </style>


### PR DESCRIPTION
This commit adds comprehensive controls for AI model parameters to address the issue of incomplete/truncated code in generated WordPress plugins.

Changes:
- Added settings for Max Tokens, Temperature, Top P, Seed, Stop Sequences, and Response Format
- Updated all API classes (OpenAI, Anthropic, Google Gemini, xAI, Custom, OpenAI Responses) to read and use these settings
- Added collapsible UI section in settings page with detailed parameter descriptions
- Parameters override model defaults when set (0 or empty = use model default)
- Max Tokens can be increased to prevent code truncation (recommended: 16384+ for complex plugins)
- Temperature and Top P provide control over output randomness/diversity
- Seed enables reproducible outputs for testing
- Stop Sequences allow custom stop conditions
- Response Format enables structured JSON outputs when needed

This solves the problem where generated plugin code was being cut off mid-generation due to low max_tokens limits (previously hardcoded at 4096 for most models).